### PR TITLE
add README for OctoAcme project management docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+# OctoAcme Project Management Docs
+
+Welcome — this folder contains OctoAcme's project management process documentation. Use this README as a single navigational entry point for onboarding and ongoing reference.
+
+Purpose
+- Provide a concise summary of how OctoAcme runs projects.
+- Surface the key artifacts, roles, and workflows teams use day-to-day.
+- Link to the full process documents for deeper guidance.
+
+Quick process summary
+- Initiation: Projects start with a one-pager that defines the problem, success metrics, stakeholders, and go/no‑go criteria.
+- Planning: Turn an approved initiative into an actionable backlog, identify dependencies/risks, estimate scope, and define the Definition of Done.
+- Execution & tracking: Work is tracked on a project board with a steady team rhythm (standups, weekly syncs, demos). PRs follow small-change, CI-first practices and include acceptance criteria.
+- Release & deployment: Releases follow a checklist with pre-release checks, staging verification, smoke tests, and a rollback playbook.
+- Risks & communication: Maintain a risk register, follow an escalation path, and use structured stakeholder communications (weekly status, incident summaries).
+- Continuous improvement: Run retrospectives after sprints/releases/incidents and track action items back into the backlog.
+
+Process documentation (detailed)
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning Guide](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](octoacme-roles-and-personas.md)
+
+How to use and contribute
+- This folder is the canonical source for OctoAcme process docs. Keep the one-pager and README current for onboarding.
+- To propose a change, use the ".github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml" template and link the issue to your PR.
+- PR requirements: small, focused changes; include affected doc link; CI checks pass before review.
+- Reviewers: assign the relevant role owner or @Enoch231 for repo-level process updates.
+
+Contact / ownership
+- Doc maintainers: Project Managers and Process Owners (see each doc header for owners).
+- For questions, open an issue or ping the project manager in the issue.


### PR DESCRIPTION
Add README to docs/ that summarizes OctoAcme project management processes and provides links to all process documents.

This PR:

Adds docs/README.md with a brief overview and navigation links
Provides contribution guidance for process docs

Related to issue: #2

Requested reviewer:

@Enoch231
